### PR TITLE
build: remove custom image builder support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,13 +3,14 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
 USER root
 WORKDIR /rdrtrigger
 COPY . .
-RUN make build
+# using a custom build directory to avoid contaminating local 'build' one
+RUN make build LOCALBUILD=internal_build
 USER default
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
 USER root
-COPY --from=builder /rdrtrigger/build/rdrtrigger /usr/bin/rdrtrigger
+COPY --from=builder /rdrtrigger/internal_build/rdrtrigger /usr/bin/rdrtrigger
 COPY --from=builder /rdrtrigger/LICENSE /licenses/rdrtrigger-license
 ENTRYPOINT ["/usr/bin/rdrtrigger"]
 USER 1001

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ $(LOCALBUILD):
 #####################################
 ###### Image related variables ######
 #####################################
-IMAGE_BUILDER ?= podman##@ Set a custom image builder if 'podman' is not available
 IMAGE_REGISTRY ?= quay.io##@ Set the image registry, defaults to 'quay.io'
 IMAGE_NAMESPACE ?= ecosystem-appeng##@ Set the image namespace, defaults to 'ecosystem-appeng'
 IMAGE_NAME ?= regional-dr-trigger-operator##@ Set the operator image name, defaults to 'regional-dr-trigger-operator'
 IMAGE_TAG ?= $(strip $(shell cat VERSION))##@ Set the operator image tag, defaults to content of the VERSION file
+IMAGE_BUILDER = podman
 
 ######################################
 ###### Bundle related variables ######


### PR DESCRIPTION
- build: segregate image and local build folder
- build: pinned image builder to podman

the docker build command is too different from podman's.
it's not worth complicating the Makefile for it, devs should use podman.
